### PR TITLE
ci: ajusta testes

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -16,11 +16,11 @@ jobs:
           POSTGRESQL_DATABASE: apisolid
         ports:
           - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+        # options: >-
+        #   --health-cmd pg_isready
+        #   --health-interval 10s
+        #   --health-timeout 5s
+        #   --health-retries 5
 
     steps:
       - name: Baixa o código
@@ -40,8 +40,11 @@ jobs:
       - name: Instala dependências
         run: pnpm install
 
+      - name: Gera os tipos de dados do Prisma
+        run: pnpm prisma generate
+
       - name: Roda os testes End To End
-        run: pnpm run test:e2e
+        run: pnpm test:e2e
         env:
           JWT_SECRET: testing
           DATABASE_URL: 'postgresql://docker:docker@localhost:5432/apisolid?schema=public'

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Instala dependências
         run: pnpm install
 
+      - name: Gera os tipos de dados do Prisma
+        run: pnpm prisma generate
+
       - name: Roda os testes End To End
-        run: pnpm run test
+        run: pnpm test


### PR DESCRIPTION
ci: comenta o health check

O health check não estava passando, o que estava encerrando o CI antes de passar pelos steps

ci: gera os tipos de dados do prisma antes dos testes

renomeia step
